### PR TITLE
Update drag-drop and add test

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,18 +12,14 @@ branches:
 
 skip_tags: true
 
-environment:
-  nodejs_version: "6"
-
 cache:
   - node_modules -> package.json
 
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm install npm
-  - .\node_modules\.bin\npm install
+  - npm install
 
 test_script:
   - node --version
-  - .\node_modules\.bin\npm --version
-  - .\node_modules\.bin\npm test
+  - npm --version
+  - npm test

--- a/examples/type/index.html
+++ b/examples/type/index.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>Panel Example</title>
+</head>
+
+<style>
+  body {
+    margin: 0;
+    padding: 0;
+    background: #e4e4e4;
+  }
+
+  .drag-row {
+    margin: 10px;
+    display: flex;
+  }
+
+  .drag-item {
+    margin: 0 10px;
+    border: 2px dashed #000;
+    width: 60px;
+    min-width: 60px;
+    height: 60px;
+    min-height: 60px;
+    line-height: 60px;
+    text-align: center;
+    display: inline-block;
+    background: #e4e4e4;
+    color: #000;
+  }
+
+  .drag-item[draggable="true"] {
+    border-style: solid;
+  }
+
+  .drag-area {
+    margin: 0 10px;
+    padding: 10px;
+    border: 2px dashed #000;
+    flex: 1;
+    min-width: 260px;
+    text-align: center;
+    white-space: nowrap;
+  }
+
+  .drag-item[drag-hovering] {
+    border-color: green;
+    color: green;
+    background: #eee;
+  }
+
+  h3 {
+    margin: 18px;
+    white-space: nowrap;
+  }
+</style>
+<body>
+
+  <h3>Drag</h3>
+  
+  <div class="drag-row">
+    <div class="drag-item" draggable="true">foo</div>
+    <div class="drag-item" draggable="true">foo(s)</div>
+    <div class="drag-item" draggable="true">bar</div>
+    <div class="drag-item" draggable="true">bar(s)</div>
+  </div>
+
+  <h3>Drop Area</h3>
+
+  <div class="drag-row">
+    <div class="drag-item" droppable="file">file</div>
+    <div class="drag-item" droppable="file" multi>file(s)</div>
+  </div>
+  
+  <div class="drag-row">
+    <div class="drag-item" droppable="foo">foo</div>
+    <div class="drag-item" droppable="foo" multi>foo(s)</div>
+  </div>
+  
+  <div class="drag-row">
+    <div class="drag-item" droppable="bar">bar</div>
+    <div class="drag-item" droppable="bar" multi>bar(s)</div>
+  </div>
+
+  <div class="drag-row">
+    <div class="drag-area drag-item" droppable="foo,bar,file">
+      <div class="drag-item" droppable="foo">foo</div>
+      <div class="drag-item" droppable="bar">bar</div>
+      <div class="drag-item" droppable="foo,bar">f&b</div>
+    </div>
+  </div>
+</body>
+
+<script>
+  'use strict'
+
+  const {drag, droppable, addon} = require('../../index');
+  let items = document.getElementsByClassName('drag-item');
+
+  Array.prototype.forEach.call(items, (item) => {
+    if (item.getAttribute('droppable')) {
+      addon (item, droppable);
+      item._initDroppable(item);
+
+      item.addEventListener('drop-area-move', event => {
+        drag.updateDropEffect(event.detail.dataTransfer, 'copy');
+      });
+    } else if (item.getAttribute('draggable')) {
+      let draggable = item.getAttribute('draggable');
+      let multi = item.innerText.length > 3;
+      let type = item.innerText.substr(0, 3);
+
+      item.addEventListener('dragstart', event => {
+        drag.start(event.dataTransfer, {
+          effect: 'copy',
+          type: type,
+          items: multi ? [`${draggable}-1`, `${draggable}-2`] : draggable,
+        });
+      });
+      item.addEventListener('dragend', event => {
+        drag.end();
+      });
+    }
+  });
+
+  window.addEventListener('dragover', event => {
+    event.dataTransfer.dropEffect = 'none';
+    event.preventDefault();
+  });
+
+</script>
+
+</html>

--- a/examples/type/main.js
+++ b/examples/type/main.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const {app, BrowserWindow} = require('electron');
+require('../../index');
+
+let win;
+
+app.on('ready', function () {
+  win = new BrowserWindow({
+    width: 400,
+    height: 550,
+  });
+  win.loadURL('file://' + __dirname + '/index.html');
+});

--- a/examples/type/package.json
+++ b/examples/type/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "app",
+  "version": "1.0.0",
+  "main": "main.js"
+}

--- a/lib/drag.js
+++ b/lib/drag.js
@@ -55,9 +55,9 @@ drag.start = function ( dataTransfer, params ) {
   _options = options;
 
   // NOTE: https://github.com/atom/electron/issues/1276
-  dataTransfer.setData('text', type);
-  dataTransfer.setData('drag/type', type);
-  dataTransfer.setData('drag/items', JSON.stringify(items));
+  // dataTransfer.setData('text', type);
+  // dataTransfer.setData('drag/type', type);
+  // dataTransfer.setData('drag/items', JSON.stringify(items));
   dataTransfer.effectAllowed = effect;
   dataTransfer.dropEffect = 'none';
 
@@ -109,7 +109,7 @@ drag.updateDropEffect = function ( dataTransfer, dropEffect ) {
 drag.type = function ( dataTransfer ) {
   if ( dataTransfer ) {
     // check if this is a file type
-    if ( dataTransfer.files.length > 0 ) {
+    if ( dataTransfer.types.indexOf('Files') !== -1 ) {
       return 'file';
     }
 
@@ -244,6 +244,14 @@ drag.getDragIcon = function (items) {
  */
 drag.options = function () {
   return _.cloneDeep(_options);
+};
+
+/**
+ * @method getLength
+ * @return {number}
+ */
+drag.getLength = function () {
+  return _items.length;
 };
 
 /**

--- a/lib/drag.js
+++ b/lib/drag.js
@@ -164,6 +164,7 @@ drag.filterFiles = function ( files ) {
 drag.items = function ( dataTransfer ) {
   if ( dataTransfer ) {
     // try to extract items from files
+    // NOTE: only available in `drop` event
     if ( dataTransfer.files.length > 0 ) {
       let results = new Array(dataTransfer.files.length);
       for ( let i = 0; i < dataTransfer.files.length; ++i ) {

--- a/lib/droppable.js
+++ b/lib/droppable.js
@@ -68,8 +68,8 @@ module.exports = {
         }
 
         // 2. check if we follow the multi drop rule
-        let dragItems = drag.items(event.dataTransfer);
-        if ( !this.multi && dragItems.length > 1 ) {
+        let length = dragType === 'file' ? event.dataTransfer.items.length : drag.getLength();
+        if ( !this.multi && length > 1 ) {
           this._canDrop = false;
           return;
         }
@@ -91,7 +91,7 @@ module.exports = {
             offsetY: event.offsetY,
 
             dragType: dragType,
-            dragItems: dragItems,
+            dragItems: drag.items(event.dataTransfer),
             dragOptions: drag.options(),
           }
         }));


### PR DESCRIPTION
1. Increased test cases for drag types
2. Update the electron and solve the problem that the `dataTransfer.files` does not exist

@jwu 

![1508144596551](https://user-images.githubusercontent.com/7113508/31603813-eb376a70-b293-11e7-8872-ba0eaa336ccb.jpg)
